### PR TITLE
Fixed bug when data for HealthChecksResult contains null value

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,3 +59,9 @@ You can customize some options, by using an overload:
     options.TreatDegradedAsSuccess = false;
 });
 ```
+### Troubleshooting
+If you are running ASP.NET Core 2.2 and have an issue where the health check results are not sent to Application Insights you might be affected by a [bug](https://github.com/aspnet/Extensions/issues/639).
+The workaround is to add the following line after you call services.AddHealthChecks() in ConfigureServices
+```csharp
+services.TryAddEnumerable(ServiceDescriptor.Singleton(typeof(IHostedService), typeof(HealthCheckPublisherOptions).Assembly.GetType("Microsoft.Extensions.Diagnostics.HealthChecks.HealthCheckPublisherHostedService")));
+```

--- a/src/Orneholm.ApplicationInsights.HealthChecks/ApplicationInsightsAvailabilityPublisher.cs
+++ b/src/Orneholm.ApplicationInsights.HealthChecks/ApplicationInsightsAvailabilityPublisher.cs
@@ -59,7 +59,7 @@ namespace Orneholm.ApplicationInsights.HealthChecks
         {
             foreach (var data in entry.Data)
             {
-                telemetry.Properties.Add($"HealthCheck-Data-{data.Key}", data.Value.ToString());
+                telemetry.Properties.Add($"HealthCheck-Data-{data.Key}", data.Value?.ToString()?? "<null>");
             }
         }
     }


### PR DESCRIPTION
And also documented a workaround for a bug when running ASP.NET 2.2 https://github.com/aspnet/Extensions/issues/639

The workaround is also documented as a note on the bottom of https://docs.microsoft.com/en-us/aspnet/core/host-and-deploy/health-checks?view=aspnetcore-2.2